### PR TITLE
Update the Cubes type

### DIFF
--- a/packages/regl-worldview/index.d.ts
+++ b/packages/regl-worldview/index.d.ts
@@ -310,7 +310,10 @@ type ShapeComponent<T> = React.ComponentType<{
   children: T[];
 }>;
 export declare const Arrows: ShapeComponent<Arrow>;
-export declare const Cubes: ShapeComponent<Cube>;
+export declare const Cubes: React.ComponentType<{
+  children: Cube[];
+  onMouseMove?: MouseHandler;
+}>;
 export declare const Cylinders: ShapeComponent<Cylinder>;
 export declare const Axes: React.ComponentType<{}>;
 export declare const Lines: ShapeComponent<Line>;


### PR DESCRIPTION
## Summary
This is related to the work for [VIZ-494] (new visualization for tracked objects). This updates the Cubes type to include the mouse event `onMouseMove`. 

## Test plan
This was tested using the mouse event added to the Cubes component for [VIZ-494]. It was tested that the mouse event is triggered as expected and the appropriate data is passed. 