### PR TITLE
Update types to include getChildrenForHitmap prop

### DIFF
--- a/packages/regl-worldview/index.d.ts
+++ b/packages/regl-worldview/index.d.ts
@@ -308,24 +308,30 @@ export declare type TextMarker = {
 
 type ShapeComponent<T> = React.ComponentType<{
   children: T[];
+  getChildrenForHitmap?: Maybe<GetChildrenForHitmap>
 }>;
 export declare const Arrows: ShapeComponent<Arrow>;
 export declare const Cubes: React.ComponentType<{
   children: Cube[];
   onMouseMove?: MouseHandler;
+  getChildrenForHitmap?: Maybe<GetChildrenForHitmap>
 }>;
 export declare const Cylinders: ShapeComponent<Cylinder>;
-export declare const Axes: React.ComponentType<{}>;
+export declare const Axes: React.ComponentType<{
+  getChildrenForHitmap?: Maybe<GetChildrenForHitmap>
+}>;
 export declare const Lines: ShapeComponent<Line>;
 export declare const Spheres: ShapeComponent<Sphere>;
 export declare const Triangles: ShapeComponent<Triangle>;
 export declare const Points: React.ComponentType<{
   children: PointType[];
   useWorldSpaceSize: boolean;
+  getChildrenForHitmap?: Maybe<GetChildrenForHitmap>
 }>;
 export declare const Grid: React.ComponentType<{
   count: number;
   size: number;
+  getChildrenForHitmap?: Maybe<GetChildrenForHitmap>
 }>;
 export declare const Text: React.ComponentType<{
   children: TextMarker[];
@@ -334,6 +340,7 @@ export declare const Text: React.ComponentType<{
 export declare const GLText: React.ComponentType<{
   children: TextMarker[];
   autoBackgroundColor?: boolean;
+  getChildrenForHitmap?: Maybe<GetChildrenForHitmap>
 }>;
 export declare const GLTFScene: React.ComponentType<{
   model: string | ((arg0: string) => Promise<GLBModel>);


### PR DESCRIPTION
## Summary
This is related to the work for [VIZ-494] - new visualization for tracked objects. This updates the various types used to include the `getChildrenForHitmap` props. This prop was set to null in the following types for performance reasons as it turns off the interactivity for the layer when set to null or undefined. 

## Test plan
This change resolves any TS errors appearing in the rviz component file and the performance improvement is visible when disabling the interactivity of all layers where it is not required (that is all layers except that for the tracked objects themselves) (less lag is visible when moving the mouse over the scene). 
