### PR TITLE
Add onClick prop to Cubes type 

### DIFF
--- a/packages/regl-worldview/index.d.ts
+++ b/packages/regl-worldview/index.d.ts
@@ -314,6 +314,7 @@ export declare const Arrows: ShapeComponent<Arrow>;
 export declare const Cubes: React.ComponentType<{
   children: Cube[];
   onMouseMove?: MouseHandler;
+  onClick?: MouseHandler;
   getChildrenForHitmap?: Maybe<GetChildrenForHitmap>
 }>;
 export declare const Cylinders: ShapeComponent<Cylinder>;


### PR DESCRIPTION
## Summary
This is related to the work for [VIZ-550] - design improvements for the new visualization for tracked objects. This PR updates the Cubes type to include the onClick props to add the ability to click on tracked objects in the scene to follow them. 

## Test plan
This change resolves any TS errors appearing in the[ related changes ](https://github.com/embarktrucks/frontier/pull/1181)to the tracked objects in the 3D module scene.