### PR TITLE
enable minmax blending

### DIFF
--- a/packages/regl-worldview/src/WorldviewContext.js
+++ b/packages/regl-worldview/src/WorldviewContext.js
@@ -151,6 +151,7 @@ export class WorldviewContext {
           "oes_texture_float",
           "oes_element_index_uint",
           "oes_standard_derivatives",
+          'EXT_blend_minmax'
         ],
         profile: getNodeEnv() !== "production",
       })


### PR DESCRIPTION

## Summary

This PR adds `EXT_blend_minmax` to webviz.

## Test plan

Tested in chrome, and it works. Querying for presence of extension also works, so alternative branches may be implemented when it's not available.

## Versioning impact
- i think `minor`
